### PR TITLE
Split release out of CI; tighten CI permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -35,46 +35,3 @@ jobs:
 
       - name: Build
         run: go build .
-
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version: '1.26.1'
-
-      - name: Generate version
-        id: version
-        run: |
-          # Get the latest tag
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-
-          # Calculate new version - increment patch version
-          IFS='.' read -r major minor patch <<< "${LATEST_TAG/v/}"
-          NEW_VERSION="v$major.$minor.$((patch+1))"
-
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "Creating new version: $NEW_VERSION"
-
-      - name: Create tag
-        run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
-          git tag -a ${{ steps.version.outputs.new_version }} -m "Release ${{ steps.version.outputs.new_version }}"
-          git push origin ${{ steps.version.outputs.new_version }}
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
-        with:
-          tag_name: ${{ steps.version.outputs.new_version }}
-          name: Release ${{ steps.version.outputs.new_version }}
-          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: '1.26.1'
+
+      - name: Generate version
+        id: version
+        run: |
+          # Get the latest tag
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+
+          # Calculate new version - increment patch version
+          IFS='.' read -r major minor patch <<< "${LATEST_TAG/v/}"
+          NEW_VERSION="v$major.$minor.$((patch+1))"
+
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "Creating new version: $NEW_VERSION"
+
+      - name: Create tag
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git tag -a ${{ steps.version.outputs.new_version }} -m "Release ${{ steps.version.outputs.new_version }}"
+          git push origin ${{ steps.version.outputs.new_version }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        with:
+          tag_name: ${{ steps.version.outputs.new_version }}
+          name: Release ${{ steps.version.outputs.new_version }}
+          generate_release_notes: true


### PR DESCRIPTION
## Summary

- Move the release job from `ci.yml` into a new `release.yml` triggered **only** on `push:main` and `workflow_dispatch`.
- `ci.yml` now declares `permissions: contents: read` at the workflow level (was previously `contents: write`).
- Release job retains `contents: write` at job scope only.

## Why

Defense-in-depth on top of the fork-PR approval setting. `release.yml` has no `pull_request` trigger and a fork PR cannot fire `push:main` or `workflow_dispatch`, so it's structurally unreachable from any PR-driven trigger.

## Test plan

- [ ] Merge → confirm release job fires on push to main
- [ ] Open a noop PR → confirm only test job runs